### PR TITLE
Feature/rework discovery capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The tap calls [Method: spreadsheets.values.get](https://developers.google.com/sh
 
 **Sheet ID**
 
+Your `sheet_id` is also required to run `--discover`, as running this will build the streams schema based on your google sheet.
+
 When you open your Google sheet, the url will look something like: 
 
 `https://docs.google.com/spreadsheets/d/abc123/edit#gid=0`
@@ -77,14 +79,14 @@ These settings expand into environment variables of:
 
 - [target-jsonl](https://hub.meltano.com/targets/jsonl)
 - [target-csv](https://hub.meltano.com/targets/csv)
-- [target-postgres transferwise](https://hub.meltano.com/targets/postgres) - Bug - Produces tables for not selected streams, `files` and an extra `spreadsheets`.
-- [target-snowflake meltano](https://hub.meltano.com/targets/snowflake--meltano)
+- [target-postgres transferwise](https://hub.meltano.com/targets/postgres)
 
 
 ---
 
 ## Roadmap
 
+- [ ] Add `target-snowflake` variant Meltano support.
 - [ ] Add setting to optionally allow renaming the sheet stream name. (File or table name output by stream).
 - [ ] Add setting to optionally allow the selection of a range of data from a sheet. (Add an optional range setting).
 
@@ -116,6 +118,8 @@ tap-google-sheets --version
 tap-google-sheets --help
 tap-google-sheets --config CONFIG --discover > ./catalog.json
 ```
+
+Note: to run `--discover` you need to have set the required tap settings found [here](#configuration).
 
 ### Initialize your Development Environment
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ These settings expand into environment variables of:
 
 ## FAQ / Things to Note
 
-* Currently the tap supports sheets that have the column name in the first row.
+* You need to provide all the setting for this tap to run the it. These settings are used to generate the stream and schema for the tap to use from your Google Sheet.
 
-(The tap builds a usable json object up by using these column names)
+* Currently the tap supports sheets that have the column name in the first row. (The tap builds a usable json object up by using these column names).
 
-* The tap will skip all columns without a name
+* The tap will skip all columns without a name. (The tap builds a usable json object up by using these column names).
 
-* If syncing to a database that all the column names are unique.
+* If syncing to a database it will not respect duplicated column names. The last column with the same name will be the only one synced along with its data.
+
+* The tap will use your Google Sheet's name as output file or table name. It will lowercase the file name, and replace any spaces with underscores.
+
+* The tap will not lower case the column names, but will again replace any spaces with underscores.
 
 ### Loaders Tested
 

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -2,15 +2,12 @@
 
 from typing import List
 
+import requests
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th
 
-from tap_google_sheets.streams import GoogleFilesStream, GoogleSheetsStream
-
-STREAM_TYPES = [
-    GoogleFilesStream,
-    GoogleSheetsStream,
-]
+from tap_google_sheets.client import GoogleSheetsBaseStream
+from tap_google_sheets.streams import GoogleSheetsStream
 
 
 class TapGoogleSheets(Tap):
@@ -39,4 +36,57 @@ class TapGoogleSheets(Tap):
 
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
-        return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+        streams: List[Stream] = []
+
+        stream_name = self.get_sheet_name()
+        stream_schema = self.get_schema()
+
+        if stream_name:
+            stream = GoogleSheetsStream(
+                tap=self, name=stream_name, schema=stream_schema
+            )
+            stream.selected
+            streams.append(stream)
+
+        return streams
+
+    def get_sheet_name(self):
+        """Get the name of the spreadsheet."""
+        config_stream = GoogleSheetsBaseStream(
+            tap=self,
+            name="config",
+            schema={"one": "one"},
+            path="https://www.googleapis.com/drive/v2/files/" + self.config["sheet_id"],
+        )
+
+        prepared_request = config_stream.prepare_request(None, None)
+
+        response: requests.Response = config_stream._request(prepared_request, None)
+
+        return response.json().get("title").lower().replace(" ", "_")
+
+    def get_schema(self):
+        """Build the schema from the data returned by the google sheet."""
+        config_stream = GoogleSheetsBaseStream(
+            tap=self,
+            name="config",
+            schema={"not": "null"},
+            path="https://sheets.googleapis.com/v4/spreadsheets/"
+            + self.config["sheet_id"]
+            + "/values/Sheet1!1:1",
+        )
+
+        prepared_request = config_stream.prepare_request(None, None)
+
+        response: requests.Response = config_stream._request(prepared_request, None)
+
+        headings, *data = response.json()["values"]
+
+        properties = []
+        for column in headings:
+            if column:
+                properties.append(
+                    th.Property(column.replace(" ", "_"), th.StringType())
+                )
+
+        return th.PropertiesList(*properties).to_dict()

--- a/tap_google_sheets/tests/test_core.py
+++ b/tap_google_sheets/tests/test_core.py
@@ -18,13 +18,32 @@ class TestCore(unittest.TestCase):
 
         self.mock_config = test_utils.MOCK_CONFIG
 
+    @responses.activate()
     def test_base_credentials_discovery(self):
         """Test basic discover sync"""
+        responses.add(
+            responses.POST,
+            "https://oauth2.googleapis.com/token",
+            json={"access_token": "new_token"},
+            status=200,
+        ),
+        responses.add(
+            responses.GET,
+            "https://www.googleapis.com/drive/v2/files/12345",
+            json={"title": "file_name"},
+            status=200,
+        ),
+        responses.add(
+            responses.GET,
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
+            json={"values": [["column_one", "column_two"]]},
+            status=200,
+        )
 
         catalog = TapGoogleSheets(self.mock_config).discover_streams()
 
         # expect valid catalog to be discovered
-        self.assertEqual(len(catalog), 2, "Total streams from default catalog")
+        self.assertEqual(len(catalog), 1, "Total streams from default catalog")
 
     # Run standard built-in tap tests from the SDK:
     @responses.activate()
@@ -39,13 +58,19 @@ class TestCore(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://www.googleapis.com/drive/v2/files/12345",
-            json={"title": "test"},
+            json={"title": "file_name"},
+            status=200,
+        ),
+        responses.add(
+            responses.GET,
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
+            json={"values": [["column_one", "column_two"]]},
             status=200,
         ),
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1",
-            json={"values": [["1"], ["2"]]},
+            json={"values": [["column_one", "column_two"], ["1", "2"]]},
             status=200,
         )
 

--- a/tap_google_sheets/tests/test_discovered_stream_name.py
+++ b/tap_google_sheets/tests/test_discovered_stream_name.py
@@ -23,12 +23,7 @@ class TestDiscoveredStreamName(unittest.TestCase):
     @responses.activate()
     def test_discovered_stream_name(self):
         """"""
-        self.column_response = {
-            "values": [
-                ["Column One", "Column Two"],
-                ["1", "1"]
-            ]
-        }
+        self.column_response = {"values": [["Column One", "Column Two"], ["1", "1"]]}
 
         responses.add(
             responses.POST,

--- a/tap_google_sheets/tests/test_ignoring_unnamed_columns.py
+++ b/tap_google_sheets/tests/test_ignoring_unnamed_columns.py
@@ -24,12 +24,13 @@ class TestCore(unittest.TestCase):
     def test_ignoring_unnamed_columns(self):
 
         self.missing_column_response = {
-            "values": [["Column_One", "", "Column_Two"], [1, 1, 1]]
+            "values": [
+                ["Column_One", "", "Column_Two"],
+                ["1", "1", "1"],
+                ["2", "2", "2"],
+            ]
         }
 
-        tap = TapGoogleSheets(config=self.mock_config)
-
-        """Run standard tap tests from the SDK."""
         responses.add(
             responses.POST,
             "https://oauth2.googleapis.com/token",
@@ -39,7 +40,13 @@ class TestCore(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://www.googleapis.com/drive/v2/files/12345",
-            json={"title": "test"},
+            json={"title": "file_name"},
+            status=200,
+        ),
+        responses.add(
+            responses.GET,
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
+            json={"values": [["Column_One", "", "Column_Two"]]},
             status=200,
         ),
         responses.add(
@@ -49,19 +56,22 @@ class TestCore(unittest.TestCase):
             status=200,
         )
 
+        tap = TapGoogleSheets(config=self.mock_config)
+
         tap.sync_all()
 
-        self.assertEqual(len(test_utils.SINGER_MESSAGES), 7)
+        self.assertEqual(len(test_utils.SINGER_MESSAGES), 6)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[0], singer.SchemaMessage)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[1], singer.SchemaMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[2], singer.SchemaMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[3], singer.RecordMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[4], singer.StateMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[5], singer.RecordMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[6], singer.StateMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[2], singer.RecordMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[3], singer.StateMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[4], singer.RecordMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[5], singer.StateMessage)
 
         self.assertEquals(
-            test_utils.SINGER_MESSAGES[3].record, {"Column_One": 1, "Column_Two": 1}
+            test_utils.SINGER_MESSAGES[2].record, {"Column_One": "1", "Column_Two": "1"}
         )
 
-        self.assertEquals(test_utils.SINGER_MESSAGES[5].record, {"title": "test"})
+        self.assertEquals(
+            test_utils.SINGER_MESSAGES[4].record, {"Column_One": "2", "Column_Two": "2"}
+        )

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -9,7 +9,7 @@ import tap_google_sheets.tests.utils as test_utils
 from tap_google_sheets.tap import TapGoogleSheets
 
 
-class TestIgnoringUnnamedColumns(unittest.TestCase):
+class TestUnderscoringColumnNamed(unittest.TestCase):
     """Test class for core tap tests."""
 
     def setUp(self):
@@ -21,13 +21,12 @@ class TestIgnoringUnnamedColumns(unittest.TestCase):
         singer.write_message = test_utils.accumulate_singer_messages
 
     @responses.activate()
-    def test_ignoring_unnamed_columns(self):
+    def test_underscoring_column_names(self):
 
-        self.missing_column_response = {
+        self.column_response = {
             "values": [
-                ["Column_One", "", "Column_Two"],
-                ["1", "1", "1"],
-                ["2", "2", "2"],
+                ["Column One", "Column Two"],
+                ["1", "1"]
             ]
         }
 
@@ -46,13 +45,13 @@ class TestIgnoringUnnamedColumns(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
-            json={"values": [["Column_One", "", "Column_Two"]]},
+            json={"values": [["Column_One", "Column_Two"]]},
             status=200,
         ),
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1",
-            json=self.missing_column_response,
+            json=self.column_response,
             status=200,
         )
 
@@ -60,19 +59,14 @@ class TestIgnoringUnnamedColumns(unittest.TestCase):
 
         tap.sync_all()
 
-        self.assertEqual(len(test_utils.SINGER_MESSAGES), 6)
+        self.assertEqual(len(test_utils.SINGER_MESSAGES), 4)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[0], singer.SchemaMessage)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[1], singer.SchemaMessage)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[2], singer.RecordMessage)
         self.assertIsInstance(test_utils.SINGER_MESSAGES[3], singer.StateMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[4], singer.RecordMessage)
-        self.assertIsInstance(test_utils.SINGER_MESSAGES[5], singer.StateMessage)
 
-        # Assert that the second unnamed column and its values are ignored
+        # Assert that column names have been underscored
         self.assertEquals(
             test_utils.SINGER_MESSAGES[2].record, {"Column_One": "1", "Column_Two": "1"}
         )
 
-        self.assertEquals(
-            test_utils.SINGER_MESSAGES[4].record, {"Column_One": "2", "Column_Two": "2"}
-        )

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -23,12 +23,7 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
     @responses.activate()
     def test_underscoring_column_names(self):
 
-        self.column_response = {
-            "values": [
-                ["Column One", "Column Two"],
-                ["1", "1"]
-            ]
-        }
+        self.column_response = {"values": [["Column One", "Column Two"], ["1", "1"]]}
 
         responses.add(
             responses.POST,
@@ -69,4 +64,3 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
         self.assertEquals(
             test_utils.SINGER_MESSAGES[2].record, {"Column_One": "1", "Column_Two": "1"}
         )
-


### PR DESCRIPTION
Enable dynamic discovery for stream name (out name for file or table) and the schema. This is done by making a request to get your Google Sheet's file metadata to use as the stream name, and the first row of the Sheet data to build the schema.

Added more testing, including for the formatting of the stream name and column names.

Updated the README with info about these changes.