### PR TITLE
Fix/fix dynamic sheet discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Setting | Required | Type | Description |
 `oauth_credentials.client_secret` | Required | String | Your google client secret
 `oauth_credentials.refresh_token` | Required | String | Your google refresh token
 `sheet_id` | Required | String | Your target google sheet id
+`stream_name` | Optional | String | Optionailly rename the stream and output file or table from the tap
+`child_sheet_name` | Optional | String | Optionally choose a different sheet from your Google Sheet file
 
 ### Environment Variable
 
@@ -62,12 +64,16 @@ These settings expand into environment variables of:
 - `TAP_GOOGLE_SHEETS_OAUTH_CREDENTIALS_CLIENT_SECRET`
 - `TAP_GOOGLE_SHEETS_OAUTH_CREDENTIALS_REFRESH_TOKEN`
 - `TAP_GOOGLE_SHEETS_SHEET_ID`
+- `TAP_GOOGLE_SHEETS_STREAM_NAME`
+- `TAP_GOOGLE_SHEETS_CHILD_SHEET_NAME`
 
 ---
 
 ## FAQ / Things to Note
 
-* You need to provide all the setting for this tap to run the it. These settings are used to generate the stream and schema for the tap to use from your Google Sheet.
+* If you do not provide a `child_sheet_name`, the tap will find the first visible sheet in your Google Sheet and try to sync the data from there.
+
+* You need to provide all the required settings for this tap to run the it. These settings are used to generate the stream and schema for the tap to use from your Google Sheet.
 
 * Currently the tap supports sheets that have the column name in the first row. (The tap builds a usable json object up by using these column names).
 
@@ -75,9 +81,9 @@ These settings expand into environment variables of:
 
 * If syncing to a database it will not respect duplicated column names. The last column with the same name will be the only one synced along with its data.
 
-* The tap will use your Google Sheet's name as output file or table name. It will lowercase the file name, and replace any spaces with underscores.
+* The tap will use your Google Sheet's name as output file or table name unless you set a `stream_name`. It will replace any spaces with underscores.
 
-* The tap will not lower case the column names, but will again replace any spaces with underscores.
+* The tap will again replace any spaces in column names with underscores.
 
 ### Loaders Tested
 
@@ -91,7 +97,6 @@ These settings expand into environment variables of:
 
 ## Roadmap
 
-- [ ] Add setting to optionally allow renaming the sheet stream name. (File or table name output by stream).
 - [ ] Add setting to optionally allow the selection of a range of data from a sheet. (Add an optional range setting).
 - [ ] Add setting to enable primary key, and select primary key(s) column(s).
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -3,25 +3,35 @@ send_anonymous_usage_stats: true
 project_id: 04da77a3-af12-49a4-b9bf-3c22845918ba
 plugins:
   extractors:
-  - name: tap-google-sheets
-    namespace: tap_google_sheets
-    pip_url: -e .
-    capabilities:
-    - state
-    - catalog
-    - discover
-    settings:
-    - name: oauth_credentials.client_id
-      kind: password
-    - name: oauth_credentials.client_secret
-      kind: password
-    - name: oauth_credentials.refresh_token
-      kind: password
-    - name: sheet_id
+    - name: tap-google-sheets
+      namespace: tap_google_sheets
+      pip_url: -e .
+      capabilities:
+        - state
+        - catalog
+        - discover
+      select:
+        - spreadsheet.*
+      settings:
+        - name: oauth_credentials.client_id
+          kind: password
+        - name: oauth_credentials.client_secret
+          kind: password
+        - name: oauth_credentials.refresh_token
+          kind: password
+        - name: sheet_id
+        - name: stream_name
+        - name: child_sheet_name
   loaders:
-  - name: target-jsonl
-    variant: andyh1203
-    pip_url: target-jsonl
-  - name: target-postgres
-    variant: transferwise
-    pip_url: pipelinewise-target-postgres
+    - name: target-jsonl
+      variant: andyh1203
+      pip_url: target-jsonl
+    - name: target-postgres
+      variant: transferwise
+      pip_url: pipelinewise-target-postgres
+    - name: target-csv
+      variant: hotgluexyz
+      pip_url: git+https://github.com/hotgluexyz/target-csv.git@0.3.3
+    - name: target-snowflake
+      variant: meltano
+      pip_url: git+https://github.com/Matatika/target-snowflake@v0.1.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths =
+    tap_google_sheets/tests
+python_files = test_*.py
+addopts = -rf --import-mode=importlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-testpaths =
-    tap_google_sheets/tests
-python_files = test_*.py
-addopts = -rf --import-mode=importlib

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -2,10 +2,18 @@
 
 from itertools import zip_longest
 from pathlib import Path
-from typing import Iterable
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Optional,
+    Union,
+)
 
 import requests
+from singer.schema import Schema
 from singer_sdk.helpers.jsonpath import extract_jsonpath
+from singer_sdk.plugin_base import PluginBase as TapBaseClass
 
 from tap_google_sheets.client import GoogleSheetsBaseStream
 
@@ -21,8 +29,7 @@ class GoogleSheetsStream(GoogleSheetsBaseStream):
     def path(self):
         """Set the path for the stream."""
         self.url_base = "https://sheets.googleapis.com/v4/spreadsheets/"
-        path = self.url_base + self.config.get("sheet_id") + "/"
-        path = path + "values/" + "Sheet1"  # self.config.get("sheet_name")
+        path = self.url_base + self.config["sheet_id"] + "/values/" + self.child_sheet_name
         return path
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -2,18 +2,10 @@
 
 from itertools import zip_longest
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Optional,
-    Union,
-)
+from typing import Iterable
 
 import requests
-from singer.schema import Schema
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.plugin_base import PluginBase as TapBaseClass
 
 from tap_google_sheets.client import GoogleSheetsBaseStream
 
@@ -23,13 +15,16 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 class GoogleSheetsStream(GoogleSheetsBaseStream):
     """Google sheets stream."""
 
+    child_sheet_name = None
     primary_key = None
 
     @property
     def path(self):
         """Set the path for the stream."""
         self.url_base = "https://sheets.googleapis.com/v4/spreadsheets/"
-        path = self.url_base + self.config["sheet_id"] + "/values/" + self.child_sheet_name
+        path = (
+            self.url_base + self.config["sheet_id"] + "/values/" + self.child_sheet_name
+        )
         return path
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -32,6 +32,18 @@ class TapGoogleSheets(Tap):
             description="Your google refresh token",
         ),
         th.Property("sheet_id", th.StringType, description="Your google sheet id"),
+        th.Property(
+            "output_name",
+            th.StringType,
+            description="Optionally rename your output file or table",
+            required=False,
+        ),
+        th.Property(
+            "child_sheet_name",
+            th.StringType,
+            description="Optionally sync data from a different sheet in your Google Sheet",
+            required=False,
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -41,7 +41,8 @@ class TapGoogleSheets(Tap):
         th.Property(
             "child_sheet_name",
             th.StringType,
-            description="Optionally sync data from a different sheet in your Google Sheet",
+            description="Optionally sync data from a different sheet in"
+            + " your Google Sheet",
             required=False,
         ),
     ).to_dict()

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -14,7 +14,6 @@ class TapGoogleSheets(Tap):
     """google_sheets tap class."""
 
     name = "tap-google-sheets"
-    sheet_name = None
 
     config_jsonschema = th.PropertiesList(
         th.Property(
@@ -46,7 +45,9 @@ class TapGoogleSheets(Tap):
 
         stream_schema = self.get_schema(google_sheet_data)
 
-        child_sheet_name = self.config.get("child_sheet_name") or self.get_first_visible_child_sheet_name(google_sheet_data)
+        child_sheet_name = self.config.get(
+            "child_sheet_name"
+        ) or self.get_first_visible_child_sheet_name(google_sheet_data)
 
         if stream_name:
             stream = GoogleSheetsStream(
@@ -64,7 +65,7 @@ class TapGoogleSheets(Tap):
             tap=self,
             name="config",
             schema={"one": "one"},
-            path="https://www.googleapis.com/drive/v2/files/" + self.config["sheet_id"]
+            path="https://www.googleapis.com/drive/v2/files/" + self.config["sheet_id"],
         )
 
         prepared_request = config_stream.prepare_request(None, None)
@@ -84,7 +85,6 @@ class TapGoogleSheets(Tap):
 
         return schema.to_dict()
 
-    
     def get_first_visible_child_sheet_name(self, google_sheet_data: requests.Response):
         """Get the name of the first visible sheet in the google sheet."""
         sheet_in_sheet_name = google_sheet_data.json()["range"].rsplit("!", 1)[0]
@@ -99,7 +99,9 @@ class TapGoogleSheets(Tap):
             schema={"not": "null"},
             path="https://sheets.googleapis.com/v4/spreadsheets/"
             + self.config["sheet_id"]
-            + "/values/" + self.config.get("child_sheet_name", "") + "!1:1",
+            + "/values/"
+            + self.config.get("child_sheet_name", "")
+            + "!1:1",
         )
 
         prepared_request = config_stream.prepare_request(None, None)

--- a/tap_google_sheets/tests/test_child_sheet_name_setting.py
+++ b/tap_google_sheets/tests/test_child_sheet_name_setting.py
@@ -13,16 +13,20 @@ class TestChildSheetNameSetting(unittest.TestCase):
     """Test class for tap setting child_sheet_name"""
 
     def setUp(self):
-        self.mock_config = test_utils.MOCK_CONFIG
+        self.mock_config = {
+            "oauth_credentials": {
+                "client_id": "123",
+                "client_secret": "123",
+                "refresh_token": "123",
+            },
+            "sheet_id": "12345",
+        }
         self.mock_config["child_sheet_name"] = "Test Sheet"
 
         responses.reset()
         del test_utils.SINGER_MESSAGES[:]
 
         singer.write_message = test_utils.accumulate_singer_messages
-
-    def tearDown(self) -> None:
-        return super().tearDown()
 
     @responses.activate()
     def test_discovered_stream_name(self):

--- a/tap_google_sheets/tests/test_child_sheet_name_setting.py
+++ b/tap_google_sheets/tests/test_child_sheet_name_setting.py
@@ -14,7 +14,7 @@ class TestChildSheetNameSetting(unittest.TestCase):
 
     def setUp(self):
         self.mock_config = test_utils.MOCK_CONFIG
-        self.mock_config["child_sheet_name"] = 'Test Sheet'
+        self.mock_config["child_sheet_name"] = "Test Sheet"
 
         responses.reset()
         del test_utils.SINGER_MESSAGES[:]
@@ -40,8 +40,12 @@ class TestChildSheetNameSetting(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Test%20Sheet!1:1",
-            json={"range": "Test%20Sheet!1:1", "values": [["Column One", "Column Two"]]},
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/"
+            + "Test%20Sheet!1:1",
+            json={
+                "range": "Test%20Sheet!1:1",
+                "values": [["Column One", "Column Two"]],
+            },
             status=200,
         ),
         responses.add(

--- a/tap_google_sheets/tests/test_child_sheet_name_setting.py
+++ b/tap_google_sheets/tests/test_child_sheet_name_setting.py
@@ -40,8 +40,7 @@ class TestChildSheetNameSetting(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/"
-            + "Test%20Sheet!1:1",
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
             json={
                 "range": "Test%20Sheet!1:1",
                 "values": [["Column One", "Column Two"]],

--- a/tap_google_sheets/tests/test_child_sheet_name_setting.py
+++ b/tap_google_sheets/tests/test_child_sheet_name_setting.py
@@ -21,6 +21,9 @@ class TestChildSheetNameSetting(unittest.TestCase):
 
         singer.write_message = test_utils.accumulate_singer_messages
 
+    def tearDown(self) -> None:
+        return super().tearDown()
+
     @responses.activate()
     def test_discovered_stream_name(self):
         """"""
@@ -40,7 +43,7 @@ class TestChildSheetNameSetting(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Test%20Sheet!1:1",
             json={
                 "range": "Test%20Sheet!1:1",
                 "values": [["Column One", "Column Two"]],

--- a/tap_google_sheets/tests/test_child_sheet_name_setting.py
+++ b/tap_google_sheets/tests/test_child_sheet_name_setting.py
@@ -47,7 +47,8 @@ class TestChildSheetNameSetting(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Test%20Sheet!1:1",
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/"
+            + "Test%20Sheet!1:1",
             json={
                 "range": "Test%20Sheet!1:1",
                 "values": [["Column One", "Column Two"]],

--- a/tap_google_sheets/tests/test_core.py
+++ b/tap_google_sheets/tests/test_core.py
@@ -35,8 +35,8 @@ class TestCore(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
-            json={"values": [["column_one", "column_two"]]},
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
+            json={"range": "Sheet1!1:1", "values": [["column_one", "column_two"]]},
             status=200,
         )
 
@@ -63,14 +63,14 @@ class TestCore(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
-            json={"values": [["column_one", "column_two"]]},
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
+            json={"range": "Sheet1!1:1", "values": [["column_one", "column_two"]]},
             status=200,
         ),
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1",
-            json={"values": [["column_one", "column_two"], ["1", "2"]]},
+            json={"range": "Sheet1", "values": [["column_one", "column_two"], ["1", "2"]]},
             status=200,
         )
 

--- a/tap_google_sheets/tests/test_core.py
+++ b/tap_google_sheets/tests/test_core.py
@@ -70,7 +70,10 @@ class TestCore(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1",
-            json={"range": "Sheet1", "values": [["column_one", "column_two"], ["1", "2"]]},
+            json={
+                "range": "Sheet1",
+                "values": [["column_one", "column_two"], ["1", "2"]],
+            },
             status=200,
         )
 

--- a/tap_google_sheets/tests/test_ignoring_unnamed_columns.py
+++ b/tap_google_sheets/tests/test_ignoring_unnamed_columns.py
@@ -1,4 +1,4 @@
-"""Tests standard tap features using the built-in SDK tests library."""
+"""Tests that the tap ignores columns with no name"""
 
 import unittest
 
@@ -10,7 +10,7 @@ from tap_google_sheets.tap import TapGoogleSheets
 
 
 class TestIgnoringUnnamedColumns(unittest.TestCase):
-    """Test class for core tap tests."""
+    """Test class for ignoring unnamed columns."""
 
     def setUp(self):
         self.mock_config = test_utils.MOCK_CONFIG
@@ -45,8 +45,8 @@ class TestIgnoringUnnamedColumns(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
-            json={"values": [["Column_One", "", "Column_Two"]]},
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
+            json={"range": "Sheet1!1:1", "values": [["Column_One", "", "Column_Two"]]},
             status=200,
         ),
         responses.add(

--- a/tap_google_sheets/tests/test_table_name_setting.py
+++ b/tap_google_sheets/tests/test_table_name_setting.py
@@ -14,7 +14,7 @@ class TestOutputNameSetting(unittest.TestCase):
 
     def setUp(self):
         self.mock_config = test_utils.MOCK_CONFIG
-        self.mock_config["stream_name"] = 'Test Output Name'
+        self.mock_config["stream_name"] = "Test Output Name"
 
         responses.reset()
         del test_utils.SINGER_MESSAGES[:]
@@ -55,5 +55,5 @@ class TestOutputNameSetting(unittest.TestCase):
 
         tap.sync_all()
 
-        # Assert the returned stream name is the output_name setting and that its underscored
+        # Assert returned stream name is the output_name setting and its underscored
         self.assertEqual(tap.discover_streams()[0].name, "Test_Output_Name")

--- a/tap_google_sheets/tests/test_table_name_setting.py
+++ b/tap_google_sheets/tests/test_table_name_setting.py
@@ -1,4 +1,4 @@
-"""Tests discovered stream names are returned underscored."""
+"""Tests tap setting stream_name."""
 
 import unittest
 
@@ -9,11 +9,12 @@ import tap_google_sheets.tests.utils as test_utils
 from tap_google_sheets.tap import TapGoogleSheets
 
 
-class TestDiscoveredStreamName(unittest.TestCase):
-    """Test class for discovered stream name."""
+class TestOutputNameSetting(unittest.TestCase):
+    """Test class test_stream_name_setting"""
 
     def setUp(self):
         self.mock_config = test_utils.MOCK_CONFIG
+        self.mock_config["stream_name"] = 'Test Output Name'
 
         responses.reset()
         del test_utils.SINGER_MESSAGES[:]
@@ -54,5 +55,5 @@ class TestDiscoveredStreamName(unittest.TestCase):
 
         tap.sync_all()
 
-        # Assert the returned stream name is lowercase and underscored
-        self.assertEqual(tap.discover_streams()[0].name, "File_Name_One")
+        # Assert the returned stream name is the output_name setting and that its underscored
+        self.assertEqual(tap.discover_streams()[0].name, "Test_Output_Name")

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -1,4 +1,4 @@
-"""Tests standard tap features using the built-in SDK tests library."""
+"""Tests column names are returned underscored."""
 
 import unittest
 
@@ -10,7 +10,7 @@ from tap_google_sheets.tap import TapGoogleSheets
 
 
 class TestUnderscoringColumnNamed(unittest.TestCase):
-    """Test class for core tap tests."""
+    """Test class for testing column naming."""
 
     def setUp(self):
         self.mock_config = test_utils.MOCK_CONFIG
@@ -39,8 +39,8 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
         ),
         responses.add(
             responses.GET,
-            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/Sheet1!1:1",
-            json={"values": [["Column_One", "Column_Two"]]},
+            "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
+            json={"range": "Sheet1!1:1","values": [["Column_One", "Column_Two"]]},
             status=200,
         ),
         responses.add(

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -40,7 +40,7 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
-            json={"range": "Sheet1!1:1","values": [["Column_One", "Column_Two"]]},
+            json={"range": "Sheet1!1:1", "values": [["Column_One", "Column_Two"]]},
             status=200,
         ),
         responses.add(


### PR DESCRIPTION
- Fixed the dynamic sheet discovery
- Added new tap setting `output_name` to allow users to specify a new name for the output table or file from the tap
- Added new tap setting `child_sheet_name` to allow users to select a different sheet in their Google Sheet to sync data from.
- Added tests around new functionality and settings