### PR TITLE
Support Python 3.11 and 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = [
 license = "GNU Affero General Public License v3.0"
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.7.1"
+python = "<3.13,>=3.7.1"
 requests = "^2.25.1"
 singer-sdk = "^0.26.0"
 click = "8.0.1"


### PR DESCRIPTION
Don't know if there's a legitimate reason for restricting the python version to `<3.11`. But it would be great to enable the newer versions of Python.