### PR TITLE
fix: handle all whitespaces in column names

### DIFF
--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable
 
 import requests
+import re
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 from tap_google_sheets.client import GoogleSheetsBaseStream
@@ -37,7 +38,7 @@ class GoogleSheetsStream(GoogleSheetsBaseStream):
             data_rows.append(
                 dict(
                     [
-                        (h.replace(" ", "_"), v or "")
+                        (re.sub("\s+", "_", h.strip()), v or "")
                         for m, h, v in zip_longest(mask, headings, values)
                         if m
                     ]

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -1,11 +1,11 @@
 """Stream type classes for tap-google-sheets."""
 
+import re
 from itertools import zip_longest
 from pathlib import Path
 from typing import Iterable
 
 import requests
-import re
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 from tap_google_sheets.client import GoogleSheetsBaseStream

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -38,7 +38,7 @@ class GoogleSheetsStream(GoogleSheetsBaseStream):
             data_rows.append(
                 dict(
                     [
-                        (re.sub("\s+", "_", h.strip()), v or "")
+                        (re.sub(r"\s+", "_", h.strip()), v or "")
                         for m, h, v in zip_longest(mask, headings, values)
                         if m
                     ]

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -103,7 +103,9 @@ class TapGoogleSheets(Tap):
         schema = th.PropertiesList()
         for column in headings:
             if column:
-                schema.append(th.Property(re.sub("\s+", "_", column.strip()), th.StringType))
+                schema.append(
+                    th.Property(re.sub("\s+", "_", column.strip()), th.StringType)
+                )
 
         return schema.to_dict()
 

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -1,9 +1,9 @@
 """google_sheets tap class."""
 
+import re
 from typing import List
 
 import requests
-import re
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th
 

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -3,6 +3,7 @@
 from typing import List
 
 import requests
+import re
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th
 
@@ -102,7 +103,7 @@ class TapGoogleSheets(Tap):
         schema = th.PropertiesList()
         for column in headings:
             if column:
-                schema.append(th.Property(column.replace(" ", "_"), th.StringType))
+                schema.append(th.Property(re.sub("\s+", "_", column.strip()), th.StringType))
 
         return schema.to_dict()
 

--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -104,7 +104,7 @@ class TapGoogleSheets(Tap):
         for column in headings:
             if column:
                 schema.append(
-                    th.Property(re.sub("\s+", "_", column.strip()), th.StringType)
+                    th.Property(re.sub(r"\s+", "_", column.strip()), th.StringType)
                 )
 
         return schema.to_dict()

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -1,6 +1,5 @@
 """Tests column names are returned underscored."""
 
-import json
 import unittest
 
 import responses

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -1,9 +1,9 @@
 """Tests column names are returned underscored."""
 
+import json
 import unittest
 
 import responses
-import json
 import singer_sdk._singerlib as singer
 
 import tap_google_sheets.tests.utils as test_utils

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -3,6 +3,7 @@
 import unittest
 
 import responses
+import json
 import singer_sdk._singerlib as singer
 
 import tap_google_sheets.tests.utils as test_utils
@@ -22,7 +23,20 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
 
     @responses.activate()
     def test_underscoring_column_names(self):
-        self.column_response = {"values": [["Column One", "Column Two"], ["1", "1"]]}
+        self.column_response = {
+            "values": [
+                [
+                    "Column One",
+                    " Column Two",
+                    "   Column Three   ",
+                    "Column\nFour",
+                    "Column  \n\tFive\n\n\t  ",
+                    "Multi Column One",
+                    "  Multi Column  Two ",
+                    "\tMulti \r\nColumn\f\vThree",
+                ], ["1"] * 8
+                ]
+            }
 
         responses.add(
             responses.POST,
@@ -39,7 +53,7 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
         responses.add(
             responses.GET,
             "https://sheets.googleapis.com/v4/spreadsheets/12345/values/!1:1",
-            json={"range": "Sheet1!1:1", "values": [["Column_One", "Column_Two"]]},
+            json={"range": "Sheet1!1:1", "values": [self.column_response["values"][0]]},
             status=200,
         ),
         responses.add(
@@ -61,5 +75,15 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
 
         # Assert that column names have been underscored
         self.assertEquals(
-            test_utils.SINGER_MESSAGES[2].record, {"Column_One": "1", "Column_Two": "1"}
+            test_utils.SINGER_MESSAGES[2].record,
+            {
+                "Column_One": "1",
+                "Column_Two": "1",
+                "Column_Three": "1",
+                "Column_Four": "1",
+                "Column_Five": "1",
+                "Multi_Column_One": "1",
+                "Multi_Column_Two": "1",
+                "Multi_Column_Three": "1",
+            },
         )

--- a/tap_google_sheets/tests/test_underscoring_column_names.py
+++ b/tap_google_sheets/tests/test_underscoring_column_names.py
@@ -34,9 +34,10 @@ class TestUnderscoringColumnNamed(unittest.TestCase):
                     "Multi Column One",
                     "  Multi Column  Two ",
                     "\tMulti \r\nColumn\f\vThree",
-                ], ["1"] * 8
-                ]
-            }
+                ],
+                ["1"] * 8,
+            ]
+        }
 
         responses.add(
             responses.POST,


### PR DESCRIPTION
I noticed that the tap only simply replaces spaces with underscores but with Google Sheets, there is always a possibility the column names will contain different types of white spaces as well (in my case we have bunch of newlines and I cannot change the source sheet).

I've extended the functionality to cover these cases and produce cleaner and easily machine readable column names (imagine querying a column with newline in name in SQL 🤯 ).

I've also adjusted the test case to cover more cases of whitespaces and showcase the functionality of this PR.