### PR TITLE
fix: get properly child_sheet_name when sheets are defined in config

### DIFF
--- a/tap_google_sheets/tap.py
+++ b/tap_google_sheets/tap.py
@@ -86,7 +86,7 @@ class TapGoogleSheets(Tap):
 
             stream_schema = self.get_schema(google_sheet_data)
 
-            child_sheet_name = self.config.get(
+            child_sheet_name = stream_config.get(
                 "child_sheet_name"
             ) or self.get_first_visible_child_sheet_name(google_sheet_data)
 


### PR DESCRIPTION
Fixes an issue where `child_sheet_name` was always read from top-level config.