### PR TITLE
fix: Remove unused direct dependency on `click`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -353,13 +353,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.0.1"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
-    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]
@@ -1752,4 +1752,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fdfee1f2bfcd847f041f9125a3313c30bbeaa719430fa0dbdd985b81a990a604"
+content-hash = "99975b44db0b52dfb0ae85ccfba8a8918319707f7e33b2539428667889862b07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ license = "GNU Affero General Public License v3.0"
 python = "^3.8"
 requests = "^2.32.3"
 singer-sdk = "^0.38.0"
-click = "8.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
Not sure why this was ever listed as a dependency, but worth removing in order to debloat install.